### PR TITLE
Also support HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
 
 script: phpunit test/unit


### PR DESCRIPTION
It seems our build already passes. Do we want to support HHVM? Not sure about how widespread WordPress deployments on HHVM are, though.